### PR TITLE
Fix README's comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ when isMainModule:
         if m.content == "ping":
             asyncCheck s.channelMessageSend(m.channel_id, "pong")
 
-    let d = newShard("Bot " & getEnv("token")) // get token in environment variables
+    let d = newShard("Bot " & getEnv("token")) # get token in environment variables
 
     proc endSession() {.noconv.} =
         waitFor d.disconnect()


### PR DESCRIPTION
The comments in the README started with `//`, so I have been changed to `#`.